### PR TITLE
feat(videoy): add autoplay, muted, loop video after gallery title

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -306,6 +306,11 @@ header .intro-text {
   margin-bottom: 10px;
 }
 
+.gallery-video {
+  max-width: 1167;
+  height: auto;
+}
+
 /* Services Section */
 #services {
   padding: 100px 0;

--- a/src/components/gallery.jsx
+++ b/src/components/gallery.jsx
@@ -35,6 +35,18 @@ export const Gallery = (props) => {
       <div className="container">
         <div className="section-title">
           <h2>Galleria</h2>
+          <div className="portfolio-item">
+            <video
+              className="gallery-video"
+              controls={false}
+              muted
+              autoPlay
+              loop
+            >
+              <source src="img/villa1280x720.mp4" type="video/mp4" /> Video non
+              supportato
+            </video>
+          </div>
         </div>
         <div className="portfolio-items">
           {props.data ? renderImagesInGroups(props.data) : "Loading..."}


### PR DESCRIPTION
- Added a video element below the h2 tag in the Gallery component
- Set video attributes: autoplay, muted, loop, and controls={false}
- Applied responsive CSS styling with the class .gallery-video
- Ensured the video source is provided as a placeholder